### PR TITLE
User Story 52: Admin Merchant Index Page + User Stories 38-41 Refactor

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -4,19 +4,16 @@ class Admin::MerchantsController < Admin::BaseController
     @merchant = Merchant.find(params[:id])
   end
 
-  def enable
-    merchant = Merchant.find(params[:id])
-    merchant.update(disabled: false)
-    merchant.items.update_all(disabled: false)
-    flash[:notice] = 'Ahoy! This merchant has re-joined the ranks.'
-    redirect_to "/merchants"
-  end
-
-  def disable
-    merchant = Merchant.find(params[:id])
-    merchant.update(disabled: true)
-    merchant.items.update_all(disabled: true)
-    flash[:notice] = 'This merchant has walked the plank.'
-    redirect_to "/merchants"
+  def update
+    @merchant = Merchant.find(params[:id])
+    if params[:enable_disable] == 'enable'
+      @merchant.enable
+      flash[:notice] = 'Ahoy! This merchant has re-joined the ranks.'
+      redirect_to "/merchants"
+    else
+      @merchant.disable
+      flash[:notice] = 'This merchant has walked the plank.'
+      redirect_to "/merchants"
+    end
   end
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -9,11 +9,10 @@ class Admin::MerchantsController < Admin::BaseController
     if params[:enable_disable] == 'enable'
       @merchant.enable
       flash[:notice] = 'Ahoy! This merchant has re-joined the ranks.'
-      redirect_to "/merchants"
     else
       @merchant.disable
       flash[:notice] = 'This merchant has walked the plank.'
-      redirect_to "/merchants"
     end
+    redirect_to "/merchants"
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -29,4 +29,14 @@ class Merchant <ApplicationRecord
   def pending_orders
     Order.joins(:items).distinct.where(items: {merchant_id: id}).where(status: 'pending')
   end
+
+  def enable
+    update(disabled: false)
+    items.update_all(disabled: false)
+  end
+
+  def disable
+    update(disabled: true)
+    items.update_all(disabled: true)
+  end
 end

--- a/app/views/merchants/index.html.erb
+++ b/app/views/merchants/index.html.erb
@@ -3,11 +3,16 @@
 <section class = "grid-container">
   <% @merchants.each do |merchant|%>
     <section class = "grid-item" id="merchant-<%= merchant.id %>">
-      <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
-      <% if current_admin? && !merchant.disabled %>
-        <%= button_to 'Disable', "/admin/merchants/#{merchant.id}/disable", method: :patch %>
-      <% elsif current_admin? && merchant.disabled %>
-        <%= button_to 'Enable', "/admin/merchants/#{merchant.id}/enable", method: :patch %>
+      <% if current_admin? %>
+      <h2><%= link_to merchant.name, "admin/merchants/#{merchant.id}" %></h2>
+      <p><%= merchant.city %>, <%= merchant.state %></p>
+        <% if merchant.disabled %>
+          <%= button_to 'Enable', "/admin/merchants/#{merchant.id}/enable", method: :patch %>
+        <% else %>
+          <%= button_to 'Disable', "/admin/merchants/#{merchant.id}/disable", method: :patch %>
+        <% end %>
+      <% else %>
+        <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
       <% end %>
     </section>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,9 +59,8 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
+    resources :merchants, only: [:show]
     get '/', to: 'dashboard#index'
-    get '/merchants/:id', to: 'merchants#show'
-    patch '/merchants/:id/disable', to: 'merchants#disable'
-    patch '/merchants/:id/enable', to: 'merchants#enable'
+    patch '/merchants/:id/:enable_disable', to: 'merchants#update'
   end
 end

--- a/spec/features/admin/merchants_index_spec.rb
+++ b/spec/features/admin/merchants_index_spec.rb
@@ -17,7 +17,33 @@ RSpec.describe 'Admin merchant index page' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
   end
 
-  describe 'as an Admin' do
+  describe 'as an Admin user' do
+    it 'I see all merchants listed with city state and link to merchant dashboard' do
+      visit '/merchants'
+
+      within "#merchant-#{@merchant_1.id}" do
+        expect(page).to have_link(@merchant_1.name)
+        expect(page).to have_content(@merchant_1.city)
+        expect(page).to have_content(@merchant_1.state)
+
+        click_link(@merchant_1.name)
+      end
+
+      expect(current_path).to eq("/admin/merchants/#{@merchant_1.id}")
+
+      visit '/merchants'
+
+      within "#merchant-#{@merchant_2.id}" do
+        expect(page).to have_link(@merchant_2.name)
+        expect(page).to have_content(@merchant_2.city)
+        expect(page).to have_content(@merchant_2.state)
+
+        click_link(@merchant_2.name)
+      end
+
+      expect(current_path).to eq("/admin/merchants/#{@merchant_2.id}")
+    end
+
     it 'I see a disable button next to merchants who are not yet disabled' do
       visit '/merchants'
 
@@ -139,6 +165,21 @@ RSpec.describe 'Admin merchant index page' do
       visit '/merchants'
 
       expect(page).to_not have_button('Enable')
+    end
+
+    it 'I cannot link to the admin/merchant dashboard' do
+      default_user = create(:user, role: 0)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(default_user)
+
+      visit '/merchants'
+
+      within "#merchant-#{@merchant_2.id}" do
+        click_link(@merchant_2.name)
+      end
+
+      expect(current_path).to_not eq("/admin/merchants/#{@merchant_2.id}")
+      expect(current_path).to eq("/merchants/#{@merchant_2.id}")
     end
   end
 


### PR DESCRIPTION
## Description
Resolves #83 
- Completed User Story 52: Admin Merchant Index Page
- Refactored User Stories 38-41: Admin Can Enable/Disable Merchants and their items to be more RESTful (refactored route for enable_disable, added enable/disable methods to Merchant model, added update method to Admin/MerchantsController)
- Test coverage dropped from 100% to 99.96% based on a line in the merchants show method that now isn't hitting; we might want to look at this together

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## RSpec Results
```
200 examples, 0 failures

Coverage report generated for RSpec to /Users/mel-rob/turing/mod_2/projects/monster_shop_part_1/coverage. 2459 / 2460 LOC (99.96%) covered.
```
